### PR TITLE
ci: fix Pages deploy and refresh README bio

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,13 +33,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Ruby
-        # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
-        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
-        with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ _site
 .DS_store
 .ruby-version
 .tweet-cache
-Gemfile.lock
 assets/libs/
 node_modules/
 vendor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,327 @@
+GIT
+  remote: https://github.com/RobertoJBeltran/jekyll-terser.git
+  revision: 1085bf66d692799af09fe39f8162a1e6e42a3cc4
+  specs:
+    jekyll-terser (0.2.3)
+      jekyll (>= 0.10.0)
+      terser (>= 1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (8.1.3)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    bibtex-ruby (6.2.0)
+      latex-decode (~> 0.0)
+      logger (~> 1.7)
+      racc (~> 1.7)
+    bigdecimal (4.1.2)
+    citeproc (1.1.0)
+      date
+      forwardable
+      json
+      namae (~> 1.0)
+      observer (< 1.0)
+      open-uri (< 1.0)
+    citeproc-ruby (2.1.8)
+      citeproc (~> 1.0, >= 1.0.9)
+      csl (~> 2.0)
+      observer (< 1.0)
+    classifier-reborn (2.3.0)
+      fast-stemmer (~> 1.0)
+      matrix (~> 0.4)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    crass (1.0.6)
+    csl (2.2.1)
+      forwardable (~> 1.3)
+      namae (~> 1.2)
+      open-uri (< 1.0)
+      rexml (~> 3.0)
+      set (~> 1.1)
+      singleton (< 1.0)
+      time (< 1.0)
+    csl-styles (2.0.2)
+      csl (~> 2.0)
+    css_parser (2.2.0)
+      addressable
+    cssminify2 (2.1.0)
+    csv (3.3.5)
+    date (3.5.1)
+    deep_merge (1.2.2)
+    drb (2.2.3)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    execjs (2.10.1)
+    fast-stemmer (1.0.2)
+    feedjira (4.0.2)
+      logger (>= 1.0, < 2)
+      loofah (>= 2.3.1, < 3)
+      sax-machine (>= 1.0, < 2)
+    ffi (1.17.4)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
+    forwardable (1.4.0)
+    forwardable-extended (2.6.0)
+    gemoji (4.1.0)
+    google-protobuf (4.35.0)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-aarch64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86_64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    html-pipeline (2.14.3)
+      activesupport (>= 2)
+      nokogiri (>= 1.4)
+    htmlcompressor (0.4.0)
+    http_parser.rb (0.8.1)
+    httparty (0.24.2)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-archives (2.3.0)
+      jekyll (>= 3.6, < 5.0)
+    jekyll-email-protect (1.1.0)
+    jekyll-feed (0.17.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-get-json (1.0.0)
+      deep_merge (~> 1.2)
+      jekyll (>= 3.0)
+    jekyll-imagemagick (1.4.0)
+      jekyll (>= 3.4)
+    jekyll-jupyter-notebook (0.0.6)
+      jekyll
+    jekyll-link-attributes (2.0.1)
+    jekyll-minifier (0.2.2)
+      cssminify2 (~> 2.1.0)
+      htmlcompressor (~> 0.4)
+      jekyll (~> 4.0)
+      json-minify (~> 0.0.3)
+      terser (~> 1.2.3)
+    jekyll-paginate-v2 (3.0.0)
+      jekyll (>= 3.0, < 5.0)
+    jekyll-regex-replace (1.1.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-scholar (7.3.0)
+      bibtex-ruby (~> 6.0)
+      citeproc-ruby (>= 2.1.6)
+      csl-styles (~> 2.0)
+      jekyll (~> 4.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-tabs (1.2.1)
+      jekyll (>= 3.0, < 5.0)
+    jekyll-toc (0.19.0)
+      jekyll (>= 3.9)
+      nokogiri (~> 1.12)
+    jekyll-twitter-plugin (2.1.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    jemoji (0.13.0)
+      gemoji (>= 3, < 5)
+      html-pipeline (~> 2.2)
+      jekyll (>= 3.0, < 5.0)
+    json (2.19.7)
+    json-minify (0.0.3)
+      json (> 0)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    latex-decode (0.4.2)
+    liquid (4.0.4)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    loofah (2.25.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    matrix (0.4.3)
+    mercenary (0.4.0)
+    mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    multi_xml (0.9.1)
+      bigdecimal (>= 3.1, < 5)
+    namae (1.2.0)
+      racc (~> 1.7)
+    nokogiri (1.19.3)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.19.3-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-musl)
+      racc (~> 1.4)
+    observer (0.1.2)
+    open-uri (0.5.0)
+      stringio
+      time
+      uri
+    ostruct (0.6.3)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    prism (1.9.0)
+    public_suffix (7.0.5)
+    racc (1.8.1)
+    rake (13.4.2)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.7.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.100.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.100.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.100.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    sax-machine (1.3.2)
+    securerandom (0.4.1)
+    set (1.1.3)
+    singleton (0.3.0)
+    stringio (3.2.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    terser (1.2.7)
+      execjs (>= 0.3.0, < 3)
+    time (0.4.2)
+      date
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.6.0)
+    uri (1.1.1)
+    webrick (1.9.2)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  ruby
+  x86_64-darwin
+  x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  classifier-reborn
+  css_parser
+  feedjira
+  httparty
+  jekyll
+  jekyll-archives
+  jekyll-email-protect
+  jekyll-feed
+  jekyll-get-json
+  jekyll-imagemagick
+  jekyll-jupyter-notebook
+  jekyll-link-attributes
+  jekyll-minifier
+  jekyll-paginate-v2
+  jekyll-regex-replace
+  jekyll-scholar
+  jekyll-sitemap
+  jekyll-tabs
+  jekyll-terser!
+  jekyll-toc
+  jekyll-twitter-plugin
+  jemoji
+  observer
+  ostruct
+  terser
+
+BUNDLED WITH
+   2.5.16

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <img src="assets/img/avatar.jpeg" alt="Profile Picture" width="200" style="border-radius: 50%"/>
 
-Check out my GitHub Pages at [ihorkatkov.github.io](https://ihorkatkov.github.io)
+Personal site: [ihorkatkov.com](https://www.ihorkatkov.com)
 
 ---
 
@@ -15,16 +15,17 @@ Check out my GitHub Pages at [ihorkatkov.github.io](https://ihorkatkov.github.io
 
 ## About Me
 
-Hey there. I’m Ihor, an AI-native product builder and software engineer with over a decade of experience in software development. I help founders, teams, and companies design, ship, and scale AI-native products, and advise on practical AI transformations.
+Hey there. I’m Ihor, an AI-native product builder and technical strategy advisor based in Amsterdam. I help founders, teams, and companies design, ship, and scale AI-native products, and advise on practical AI transformations.
 
 ## Current Work
 
-I'm a Founding Engineer at [Neno](https://neno.co), building AI-powered financial services for European SMEs.
+I'm a Founding Engineer at [Neno](https://neno.co), Europe's first AI-powered financial services company. I work on document processing pipelines, banking infrastructure, and AI agents that automate financial workflows for European SMEs.
 
 ## Research Interests / Expertise
 
 * AI-native products
-* AI agents
-* Fintech infrastructure
-* Software engineering
+* AI agents and agent infrastructure
+* AI transformation strategy
+* Fintech and banking infrastructure
+* Software architecture
 * Entrepreneurship


### PR DESCRIPTION
## Summary
- Remove the stale Ruby 3.1 setup from the Pages deploy workflow so the build uses Ruby 3.3.5 consistently
- Commit Gemfile.lock for deterministic Jekyll dependency resolution
- Refresh README bio and expertise sections

## Validation
- CI Build Check passed on PR: https://github.com/ihorkatkov/ihorkatkov.github.io/actions/runs/26767629837
- Manual Deploy workflow_dispatch on this branch: build job passed, including dependency install, PurgeCSS, Jekyll build, and artifact upload: https://github.com/ihorkatkov/ihorkatkov.github.io/actions/runs/26767722916
- The branch workflow_dispatch deploy job failed because it was run from a non-main branch; the build portion validates the deploy failure fix.